### PR TITLE
Fixes to colour's copied out

### DIFF
--- a/NSColorAdditions.m
+++ b/NSColorAdditions.m
@@ -248,7 +248,7 @@
         NSString *green = [self _componentToString: [color greenComponent]];
         NSString *blue  = [self _componentToString: [color blueComponent]];
         NSString *alpha = [self _componentToString: [color alphaComponent] withFormat:@"%.2f"];
-        return [NSString stringWithFormat: @"UIColor(red:%@ green:%@ blue:%@ alpha:%@)", red, green, blue, alpha];
+        return [NSString stringWithFormat: @"UIColor(red:%@, green:%@, blue:%@, alpha:%@)", red, green, blue, alpha];
     }
 }
 
@@ -262,7 +262,7 @@
     NSString *blue  = [self _componentToString: [color blueComponent]];
     NSString *alpha = [self _componentToString: [color alphaComponent] withFormat:@"%.2f"];
 
-    return [NSString stringWithFormat: @"UIColor.colorWithRed(%@ green:%@ blue%@ alpha:%@)", red, green, blue, alpha];
+    return [NSString stringWithFormat: @"UIColor.colorWithRed(%@ green:%@ blue:%@ alpha:%@)", red, green, blue, alpha];
   }
 }
 


### PR DESCRIPTION
With Swift:

![screen shot 2016-03-10 at 3 16 22 pm](https://cloud.githubusercontent.com/assets/49038/13683124/11297ef0-e6d3-11e5-90f3-08de7e2cdd36.png)

Spotted a typo in the rubymotion one too :+1: - haven't verified, but looks correct to me
